### PR TITLE
Set consent_withdrawn using consent field from Rapid Pro

### DIFF
--- a/analysis_file/analysis_file.py
+++ b/analysis_file/analysis_file.py
@@ -1,6 +1,9 @@
 import argparse
 import sys
+import time
 
+from core_data_modules.cleaners import Codes
+from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataJsonIO, TracedDataCSVIO
 
 from lib.analysis_keys import AnalysisKeys
@@ -58,6 +61,8 @@ if __name__ == "__main__":
         "repeated_raw"
     ]
 
+    rapid_pro_consent_key = "esc4jmcna_consent_s07e01_complete"
+
     # Load cleaned and coded message/survey data
     with open(data_input_path, "r") as f:
         data = TracedDataJsonIO.import_json_to_traced_data_iterable(f)
@@ -99,6 +104,11 @@ if __name__ == "__main__":
 
     # Determine consent
     Consent.determine_consent(user, data, export_keys)
+
+    # Set consent withdrawn based on auto-categorisation in Rapid Pro
+    for td in data:
+        if td.get(rapid_pro_consent_key) == "yes":  # Not using Codes.YES because this is from Rapid Pro
+            td.append_data({"withdrawn_consent": Codes.TRUE}, Metadata(user, Metadata.get_call_location(), time.time()))
 
     # Export to CSV with one respondent per row
     to_be_folded = []

--- a/analysis_file/analysis_file.py
+++ b/analysis_file/analysis_file.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         "repeated_raw"
     ]
 
-    rapid_pro_consent_key = "esc4jmcna_consent_s07e01_complete"
+    rapid_pro_consent_withdrawn_key = "esc4jmcna_consent_s07e01_complete"
 
     # Load cleaned and coded message/survey data
     with open(data_input_path, "r") as f:
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     # Set consent withdrawn based on auto-categorisation in Rapid Pro
     for td in data:
-        if td.get(rapid_pro_consent_key) == "yes":  # Not using Codes.YES because this is from Rapid Pro
+        if td.get(rapid_pro_consent_withdrawn_key) == "yes":  # Not using Codes.YES because this is from Rapid Pro
             td.append_data({"withdrawn_consent": Codes.TRUE}, Metadata(user, Metadata.get_call_location(), time.time()))
 
     # Export to CSV with one respondent per row

--- a/analysis_file/analysis_file.py
+++ b/analysis_file/analysis_file.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     export_keys.extend(demog_keys)
     export_keys.extend(evaluation_keys)
 
-    # Determine consent
+    # Set consent withdrawn based on presence of data coded as "stop"
     Consent.determine_consent(user, data, export_keys)
 
     # Set consent withdrawn based on auto-categorisation in Rapid Pro


### PR DESCRIPTION
STOP messages caught by Rapid Pro wouldn't placed into the district_review field for manual verification, so we need to get them from the consent field instead.